### PR TITLE
fix incorrect FLAG_COMPAT_VA_39_BIT flag stripping and integer shifting in do_execveat_common

### DIFF
--- a/fs/exec.c
+++ b/fs/exec.c
@@ -1962,15 +1962,15 @@ static int do_execveat_common(int fd, struct filename *filename,
 	 * further execve() calls fail. */
 	current->flags &= ~PF_NPROC_EXCEEDED;
 
-	bprm = alloc_bprm(fd, filename, flags);
+#define FLAG_COMPAT_VA_39_BIT BIT(30)
+
+	bprm = alloc_bprm(fd, filename, flags & ~FLAG_COMPAT_VA_39_BIT);
 	if (IS_ERR(bprm)) {
 		retval = PTR_ERR(bprm);
 		goto out_ret;
 	}
 
-#define FLAG_COMPAT_VA_39_BIT (1 << 31)
 	bprm->compat_va_39_bit = flags & FLAG_COMPAT_VA_39_BIT;
-	flags &= ~FLAG_COMPAT_VA_39_BIT; // flag validation fails when it sees an unknown flag
 
 	retval = count(argv, MAX_ARG_STRINGS);
 	if (retval == 0)


### PR DESCRIPTION
execveat fails when FLAG_COMPAT_VA_39_BIT is set.

The code in do_execveat_common does not properly strip FLAG_COMPAT_VA_39_BIT before calling alloc_bprm, causing alloc_bprm to fail.

fs/exec.c also defines FLAG_COMPAT_VA_39_BIT as (1 << 31), which is undefined behavior as 1 defaults to int.


This PR fixes these issues.