### PR TITLE
11thgen bootfixes

### DIFF
--- a/arch/arm64/kvm/arm.c
+++ b/arch/arm64/kvm/arm.c
@@ -23,6 +23,7 @@
 #include <linux/sched/stat.h>
 #include <linux/shrinker.h>
 #include <linux/psci.h>
+#include <linux/security.h>
 #include <trace/events/kvm.h>
 
 #define CREATE_TRACE_POINTS
@@ -2409,9 +2410,13 @@ static int __init init_subsystems(void)
 
 	kvm_register_perf_callbacks(NULL);
 
-	err = hyp_trace_init_tracefs();
-	if (err)
-		kvm_err("Failed to initialize Hyp tracing\n");
+	if (security_locked_down(LOCKDOWN_TRACEFS)) {
+		kvm_err("Hyp tracing disabled due to lockdown\n");
+	} else {
+		err = hyp_trace_init_tracefs();
+		if (err)
+			kvm_err("Failed to initialize Hyp tracing\n");
+	}
 out:
 	if (err)
 		hyp_cpu_pm_exit();

--- a/scripts/Makefile.autofdo
+++ b/scripts/Makefile.autofdo
@@ -12,9 +12,7 @@ endif
 
 ifdef CLANG_AUTOFDO_PROFILE
   CFLAGS_AUTOFDO_CLANG += -fprofile-sample-use=$(CLANG_AUTOFDO_PROFILE) -ffunction-sections
-  CFLAGS_AUTOFDO_CLANG += -fsplit-machine-functions
   RUSTFLAGS_AUTOFDO_CLANG += -Zprofile-sample-use=$(CLANG_AUTOFDO_PROFILE) -Zfunction-sections=y
-  RUSTFLAGS_AUTOFDO_CLANG += -Cllvm-args=-split-machine-functions
 endif
 
 ifdef CONFIG_LTO_CLANG_THIN
@@ -22,7 +20,6 @@ ifdef CONFIG_LTO_CLANG_THIN
     KBUILD_LDFLAGS += --lto-sample-profile=$(CLANG_AUTOFDO_PROFILE)
   endif
   KBUILD_LDFLAGS += --mllvm=-enable-fs-discriminator=true --mllvm=-improved-fs-discriminator=true -plugin-opt=thinlto
-  KBUILD_LDFLAGS += -plugin-opt=-split-machine-functions
 endif
 
 export CFLAGS_AUTOFDO_CLANG RUSTFLAGS_AUTOFDO_CLANG


### PR DESCRIPTION
Should also merge with https://github.com/GrapheneOS/kernel_common-6.12/pull/29 since it was tested with that too

This fixes booting issues at least on kodiak

Also need to use `--extra_git_project=private` too for the build scripts when building, otherwise https://gitlab.com/grapheneos/kernel_pixel_spacecraft/-/blob/17-base/private/google-modules/soc/rdo/drivers/soc/google/pixel-debug-kinfo.c?ref_type=heads#L87 would have `THIS_MODULE->scmversion` as NULL